### PR TITLE
Fix finding location of Channels.csv, allow Channel IDs to be non-numeric

### DIFF
--- a/bin/collect_dataset_info.py
+++ b/bin/collect_dataset_info.py
@@ -129,7 +129,7 @@ def get_channel_metadata(data_dir: Path, channels_path: Path):
     if channels_path is not None and not channels_path.exists():
         print("Error no " + str(channels_path))
     if channels_path is None:
-        for file in data_dir.glob("*.channels.csv"):
+        for file in data_dir.glob("**/*.channels.csv"):
             channels_path = file
         if channels_path is None:
             print("No *.channels.csv file found in " + str(data_dir))

--- a/bin/test/test_collect_dataset_info.py
+++ b/bin/test/test_collect_dataset_info.py
@@ -21,7 +21,7 @@ def test_get_segm_channel_ids_from_ome():
 def test_get_channel_metadata():
     result = get_channel_metadata(Path("test_files"), None)
     print(result)
-    assert result == {'nucleus': 0, 'cell': 4}
+    assert result == {'nucleus': "Channel:0:0", 'cell': "Channel:0:4"}
 
 
 def test_get_channel_metadata_file_misssing():
@@ -33,17 +33,18 @@ def test_get_channel_metadata_file_misssing():
 def test_get_segm_channel_names_from_ome():
     result, result2 = get_segm_channel_names_from_ome(
         Path("test_files/16-11_Scan1.compressed.ome.tiff"),
-        {'nucleus': 0, 'cell': 4}
+        {'nucleus': "Channel:0:0", 'cell': "Channel:0:4"}
     )
     assert result == {'DAPI': 0, 'E-cadherin': 4}
     assert result2 == {'cell': 'E-cadherin', 'nucleus': 'DAPI'}
 
 
 def test_get_pixel_size_from_img():
-    with tif.TiffFile("test_files/16-11_Scan1.compressed.ome.tiff") as TF:
+    file_path = "test_files/16-11_Scan1.compressed.ome.tiff"
+    with tif.TiffFile(file_path) as TF:
         dimensions = get_physical_size_quantities(TF)
         print(dimensions)
         print(dimensions["X"].magnitude)
         print(format(dimensions["X"].units, '~'))
-        results = get_pixel_size_from_img(TF)
+        results = get_pixel_size_from_img(file_path)
         assert results == (0.5082855933597976, 0.5082855933597976, "µm", "µm")

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 import yaml
 
@@ -28,13 +28,12 @@ def save_pipeline_config(config: dict, out_path: Path):
         yaml.safe_dump(config, s)
 
 
-def get_channel_names_from_ome(xml) -> Dict[str, int]:
+def get_channel_names_from_ome(xml) -> Dict[str, Tuple[str, int]]:
     pixels = xml.find("Image").find("Pixels")
     channels = pixels.findall("Channel")
     ch_names_ids = dict()
-    for ch in channels:
+    for n, ch in enumerate(channels):
         ch_name = ch.get("Name")
         ch_id_ome = ch.get("ID")  # e.g. Channel:0:12
-        ch_id = int(ch_id_ome.split(":")[-1])
-        ch_names_ids[ch_name] = ch_id
+        ch_names_ids[ch_name] = (ch_id_ome, n)
     return ch_names_ids


### PR DESCRIPTION
This fixes the issue where the Channels.csv file wasn't being checked in subdirs.

Also now allows Chanel IDs to be any legal string as they don't have to be numeric as previously assumed.